### PR TITLE
fix: ArgoCD Image Updater digest 전략 설정

### DIFF
--- a/argocd/applications/dev/order-service.yaml
+++ b/argocd/applications/dev/order-service.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     argocd-image-updater.argoproj.io/image-list: "order-api=youngmin1085/order-service"
     argocd-image-updater.argoproj.io/order-api.update-strategy: "digest"
+    argocd-image-updater.argoproj.io/order-api.allow-tags: "regexp:^dev$"
     argocd-image-updater.argoproj.io/write-back-method: git
 spec:
   project: dev-project # 애플리케이션을 논리적으로 그룹화하는 프로젝트 이름 (RBAC 밎 접근 제어에 활용)

--- a/argocd/applications/dev/user-service.yaml
+++ b/argocd/applications/dev/user-service.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     argocd-image-updater.argoproj.io/image-list: "user-api=youngmin1085/user-service"
     argocd-image-updater.argoproj.io/user-api.update-strategy: "digest"
+    argocd-image-updater.argoproj.io/user-api.allow-tags: "regexp:^dev$"
     argocd-image-updater.argoproj.io/write-back-method: git
 spec:
   project: dev-project

--- a/argocd/install/dev/image-updater/values.yaml
+++ b/argocd/install/dev/image-updater/values.yaml
@@ -4,6 +4,6 @@ config:
       api_url: "https://registry-1.docker.io" # 레지스트리 API URL
       prefix: "docker.io" # 이미지 Pull 시 사용할 이미지 경로 접두사
       ping: true # 레지스트리에 접근 가능한지 체크할지 여부 (true면 주기적으로 ping)
-      credentials: secret:argocd/docker-hub-creds # 인증 정보가 저장된 ArgoCD secret 경로
+      credentials: pullsecret:argocd/docker-hub-creds # 인증 정보가 저장된 ArgoCD secret 경로
       default: true # 여러 레지스트리 중 기본으로 사용할 레지스트리로 설정
   logLevel: debug # 로그 레벨 설정

--- a/charts/order-service/values-dev.yaml
+++ b/charts/order-service/values-dev.yaml
@@ -14,7 +14,7 @@ deployment:
   containers:
     - name: order-service-api
       image: youngmin1085/order-service
-      tag: 1.0.0
+      tag: dev
       imagePullPolicy: Always
       ports:
         - name: http

--- a/charts/user-service/values-dev.yaml
+++ b/charts/user-service/values-dev.yaml
@@ -14,7 +14,7 @@ deployment:
   containers:
     - name: user-service-api
       image: youngmin1085/user-service
-      tag: 1.0.0
+      tag: dev
       ports:
         - name: http
           containerPort: 8080


### PR DESCRIPTION
1. ArgoCD Applications에 allow-tags 추가
2. values-dev.yaml 이미지 태그를 dev로 변경
3. digest 전략으로 환경별 태그 추적